### PR TITLE
remove class loading for "driver-class-name"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,18 +16,17 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+          server-id: ossrh
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_PASSWORD
+
+      - name: setup-github-release
+        run: sed -i -e 's/<\/servers>/<server><id>github<\/id><username>x-access-token<\/username><password>${GITHUB_TOKEN}<\/password><\/server><\/servers>/g' /home/runner/.m2/settings.xml
 
       - name: setup-gpg
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         run: echo ${GPG_PRIVATE_KEY} | base64 --decode | gpg --batch --import
-
-      - name: setup-maven-settings
-        uses: s4u/maven-settings-action@v1
-        with:
-          servers: '[{"id": "ossrh", "username": "${OSSRH_USERNAME}", "password": "${OSSRH_PASSWORD}"}, {"id": "github", "username": "x-access-token", "password": "${GITHUB_TOKEN}"}]'
-          properties: '[{"gpg.executable": "gpg"}, {"gpg.passphrase": "${GPG_PASSPHRASE}"}]'
-          sonatypeSnapshots: true
 
       - name: checkout
         uses: actions/checkout@v1
@@ -43,7 +42,7 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        run: mvn clean verify deploy
+        run: mvn clean verify deploy -Dgpg.executable=gpg -Dgpg.passphrase=${GPG_PASSPHRASE}
 
       - name: sonar-analyse
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /.project
 /.settings/
 /target/
+/.idea
+/*.iml

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <dependency>
 	<groupId>com.avides.springboot.springtainer</groupId>
 	<artifactId>springtainer-mysql</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<scope>test</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.avides.springboot.springtainer</groupId>
   <artifactId>springtainer-mysql</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1-SNAPSHOT</version>
 
   <name>springtainer-mysql</name>
   <description>MySQL test-container</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.avides.springboot.springtainer</groupId>
   <artifactId>springtainer-mysql</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.0.1</version>
 
   <name>springtainer-mysql</name>
   <description>MySQL test-container</description>

--- a/src/main/java/com/avides/springboot/springtainer/mysql/EmbeddedMysqlContainerAutoConfiguration.java
+++ b/src/main/java/com/avides/springboot/springtainer/mysql/EmbeddedMysqlContainerAutoConfiguration.java
@@ -137,7 +137,6 @@ public class EmbeddedMysqlContainerAutoConfiguration
         private Connection createSqlConnection(MysqlProperties properties)
                 throws InstantiationException, IllegalAccessException, ClassNotFoundException, SQLException
         {
-            Class.forName("com.mysql.jdbc.Driver").newInstance();
             String connectionCommand = generateSqlConnectionUrl(properties) + "?verifyServerCertificate=false&useSSL=false&user=root&password=" + properties
                     .getRootPassword();
             return DriverManager.getConnection(connectionCommand);

--- a/src/test/java/com/avides/springboot/springtainer/mysql/AbstractIT.java
+++ b/src/test/java/com/avides/springboot/springtainer/mysql/AbstractIT.java
@@ -14,7 +14,7 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.core.DockerClientBuilder;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(properties = { "spring.datasource.driver-class-name=com.mysql.jdbc.Driver", "spring.datasource.url=${embedded.container.mysql.url}", "spring.datasource.username=root", "spring.datasource.password=${embedded.container.mysql.root-password}" })
+@SpringBootTest(properties = { "spring.datasource.url=${embedded.container.mysql.url}", "spring.datasource.username=root", "spring.datasource.password=${embedded.container.mysql.root-password}" })
 public abstract class AbstractIT
 {
     protected DockerClient dockerClient = DockerClientBuilder.getInstance().build();


### PR DESCRIPTION
remove class loading for driver-class-name, it throws deprecation warning when you use it with current spring boot version

```
Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.
```

I tested it locally and it run through, would appreciate if you could add this change and create a new release